### PR TITLE
Add a `layout` field to SET_CHAT_COMPLETE_RESULTS.

### DIFF
--- a/builtins/__tests__/core.spec.js
+++ b/builtins/__tests__/core.spec.js
@@ -20,6 +20,7 @@ describe('core', () => {
       setImmediate(() => {
         expect(core.userAgent.emit.calls.count()).toEqual(2)
         expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {
+          layout: 'tile',
           results: [
             {text: '/h1 '},
             {text: '/h2 '},
@@ -67,6 +68,7 @@ describe('core', () => {
       setImmediate(() => {
         expect(core.userAgent.emit.calls.count()).toEqual(2)
         expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {
+          layout: 'tile',
           results: [
             {text: '🎳'},
             {text: '🙇'}

--- a/builtins/__tests__/donger.spec.js
+++ b/builtins/__tests__/donger.spec.js
@@ -18,7 +18,9 @@ describe('donger', () => {
     donger.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: 'donger'}, tag: 123})
     setImmediate(() => {
       expect(donger.userAgent.emit.calls.count()).toEqual(2)
-      expect(donger.userAgent.emit.calls.argsFor(1)[1].results.length).toEqual(13)
+      const {layout, results} = donger.userAgent.emit.calls.argsFor(1)[1]
+      expect(results.length).toEqual(13)
+      expect(layout).toEqual('tile')
       done()
     })
   })

--- a/lib/Feature.js
+++ b/lib/Feature.js
@@ -88,7 +88,8 @@ class Feature {
               if (!current.chatCompletions) return total
               return total.concat(current.chatCompletions)
             }, [])
-            this._userAgent.emit(Events.SET_CHAT_COMPLETE_RESULTS, {replyTag: tag, results})
+            const layout = getChatCompleteLayout(results)
+            this._userAgent.emit(Events.SET_CHAT_COMPLETE_RESULTS, {replyTag: tag, layout, results})
           }
 
           const stagedMessages = results.filter(r => r && r.stagedMessage)
@@ -101,6 +102,13 @@ class Feature {
       })
     }
   }
+}
+
+// TODO: Get this from the features rather than a heuristic.
+function getChatCompleteLayout(chatCompletions) {
+  if (!chatCompletions || !chatCompletions.length) return undefined
+  if (chatCompletions.every(c => c.media)) return 'row'
+  return 'tile'
 }
 
 export default Feature

--- a/lib/userAgent.js
+++ b/lib/userAgent.js
@@ -23,6 +23,11 @@ class UserAgent extends EventEmitter {
    * @event UserAgent#SET_CHAT_COMPLETE_RESULTS
    * @mixes event:TAGGED_MESSAGE
    * @type {!Object}
+   * @property {string} layout - how to layout the results: "column" (a single
+   *     column of results, scrolling vertically if needed), "row" (a single
+   *     row of results, scrolling horizontally as needed) or "tile" (as many
+   *     per row as fit, wrapping to additional rows as needed). Defaults to
+   *     row.
    * @property {UserAgent~ChatCompletion[]} results - array of results to be
    *     displayed to the user.
    */

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pretest": "eslint --ignore-path .gitignore --ignore-pattern 'pseudo/*' .",
     "start": "webpack-dev-server --port=8888",
     "test": "NODE_ENV=test jest --coverage",
-    "test:watch": "npm test -- --watchAll"
+    "test:watch": "NODE_ENV=test jest --watchAll"
   },
   "dependencies": {
     "node-fetch": "^1.6.1",


### PR DESCRIPTION
This tells the embedder whether to display the group of results as a column,
row or tile.

This patch doesn't expose that setting to the high-level feature API under
the theory that it'll be better for the framework to choose some reasonable
default in most cases. We can easily plumb that through if we like.

Also, fix `npm run test:watch` so that it doesn't spam the console w/ coverage
information.

Ref #59
