### PR TITLE
Return entity ranges rather than canonical messages.

### DIFF
--- a/builtins/__tests__/core.spec.js
+++ b/builtins/__tests__/core.spec.js
@@ -123,7 +123,10 @@ describe('core', () => {
       core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: 'hello @archer, whats up?'}, tag: 123})
       setImmediate(() => {
         expect(core.userAgent.emit.calls.count()).toEqual(3)
-        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {text: 'hello <@234>, whats up?'}, replyTag: 123})
+        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {
+          text: 'hello @archer, whats up?',
+          entities: [{id: '234', isIdentity: true, start: 6, length: 7}]
+        }, replyTag: 123})
         expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {results: [], replyTag: 123})
         done()
       })
@@ -133,7 +136,10 @@ describe('core', () => {
       core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: 'check out the #archer channel'}, tag: 123})
       setImmediate(() => {
         expect(core.userAgent.emit.calls.count()).toEqual(3)
-        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {text: 'check out the <@234> channel'}, replyTag: 123})
+        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {
+          text: 'check out the @archer channel',
+          entities: [{id: '234', isIdentity: true, start: 14, length: 7}]
+        }, replyTag: 123})
         expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {results: [], replyTag: 123})
         done()
       })
@@ -143,7 +149,10 @@ describe('core', () => {
       core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: '#isis '}, tag: 123})
       setImmediate(() => {
         expect(core.userAgent.emit.calls.count()).toEqual(3)
-        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {text: '<#789> '}, replyTag: 123})
+        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {
+          text: '#isis ',
+          entities: [{id: '789', isIdentity: false, start: 0, length: 5}]
+        }, replyTag: 123})
         expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {results: [], replyTag: 123})
         done()
       })
@@ -193,7 +202,10 @@ describe('core', () => {
       core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: 'Who is @krieger and who is the clone?'}, tag: 123})
       setImmediate(() => {
         expect(core.userAgent.emit.calls.count()).toEqual(3)
-        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {text: 'Who is <@567> and who is the clone?'}, replyTag: 123})
+        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {
+          text: 'Who is @krieger and who is the clone?',
+          entities: [{id: '567', isIdentity: true, start: 7, length: 8}]
+        }, replyTag: 123})
         expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {results: [], replyTag: 123})
         done()
       })
@@ -222,7 +234,10 @@ describe('core', () => {
       core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: '#espionage '}, tag: 123})
       setImmediate(() => {
         expect(core.userAgent.emit.calls.count()).toEqual(3)
-        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {text: '<#890> '}, replyTag: 123})
+        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {
+          text: '#espionage ',
+          entities: [{id: '890', isIdentity: false, start: 0, length: 10}]
+        }, replyTag: 123})
         expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {results: [], replyTag: 123})
         done()
       })
@@ -232,7 +247,10 @@ describe('core', () => {
       core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: '#isis/espionage '}, tag: 123})
       setImmediate(() => {
         expect(core.userAgent.emit.calls.count()).toEqual(3)
-        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {text: '<#890> '}, replyTag: 123})
+        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {
+          text: '#isis/espionage ',
+          entities: [{id: '890', isIdentity: false, start: 0, length: 15}]
+        }, replyTag: 123})
         expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {results: [], replyTag: 123})
         done()
       })
@@ -266,7 +284,10 @@ describe('core', () => {
       core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: '@archer/dangerzone '}, tag: 123})
       setImmediate(() => {
         expect(core.userAgent.emit.calls.count()).toEqual(3)
-        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {text: '<#901> '}, replyTag: 123})
+        expect(core.userAgent.emit).toHaveBeenCalledWith('UPDATE_STAGED_MESSAGE', {message: {
+          text: '@archer/dangerzone ',
+          entities: [{id: '901', isIdentity: true, start: 0, length: 18}]
+        }, replyTag: 123})
         expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {results: [], replyTag: 123})
         done()
       })

--- a/builtins/core.other.js
+++ b/builtins/core.other.js
@@ -37,7 +37,7 @@ feature.listen({
 
     const subQuery = queryParts[1]
     const subResults = getByPrefix(subQuery)
-    return subResults.filter(s => parentResults.map(p => p.id).includes(s.parentId))
+    return subResults.filter(s => parentResults.map(p => p.id).includes(s.parentId)).map(s => Object.assign({}, s, {isIdentity: parentResults[0].isIdentity}))
   }
 })
 

--- a/lib/MentionListener.js
+++ b/lib/MentionListener.js
@@ -40,7 +40,7 @@ class MentionListener extends Listener {
   }
 
   onSetStagedMessage(message) {
-    const {text} = message
+    const {entities, text} = message
     const partialMatch = partialMentionRegExp.exec(text)
     if (partialMatch) {
       const partialMention = partialMatch[1]
@@ -58,9 +58,16 @@ class MentionListener extends Listener {
     return results.then(results => {
       const result = results[0]
       if (!result) return {chatCompletions: []}
-      return {chatCompletions: [], stagedMessage: {
-        text: text.replace(mention, `<${result.isIdentity ? '@' : '#'}${result.id}>`)
-      }}
+      const start = fullMatch[0][0] === ' ' || fullMatch[0][0] === '\n' ? fullMatch.index + 1 : fullMatch.index
+      const newEntities = (entities || []).concat([{
+        id: result.id,
+        isIdentity: Boolean(result.isIdentity),
+        start,
+        length: mention.length
+      }])
+      const requiredToken = result.isIdentity ? '@' : '#'
+      const newText = text[start] === requiredToken ? text : text.substr(0, start) + requiredToken + text.substr(start + 1)
+      return {chatCompletions: [], stagedMessage: {entities: newEntities, text: newText}}
     })
   }
 }

--- a/lib/Message.js
+++ b/lib/Message.js
@@ -8,4 +8,7 @@
  *     base-16 string.
  * @property {?string} text Plain text of the message.
  * @property {?double} time Sent timestamp. Used as a unique identifier.
+ * @property {?Object[]} entities A list of entities that apply to the message.
+ *     Each entity consists of the |start| and |length| of the range to which it
+ *     applies as well as the entity's |id| and whether it |isIdentity|.
  */


### PR DESCRIPTION
This is closer to the model that iOS uses and makes draftjs integration easier
too.

Ref #12
