### PR TITLE
Don't auto mention partial mentions.

### DIFF
--- a/builtins/__tests__/core.spec.js
+++ b/builtins/__tests__/core.spec.js
@@ -135,6 +135,15 @@ describe('core', () => {
       })
     })
 
+    it('does not mention partial matches', done => {
+      core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: 'hello @arch '}, tag: 123})
+      setImmediate(() => {
+        expect(core.userAgent.emit.calls.count()).toEqual(2)
+        expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {results: [], replyTag: 123})
+        done()
+      })
+    })
+
     it('mentions identity channel', done => {
       core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: 'check out the #archer channel'}, tag: 123})
       setImmediate(() => {

--- a/lib/MentionListener.js
+++ b/lib/MentionListener.js
@@ -85,7 +85,8 @@ class MentionListener extends Listener {
     let results = this._on({mention})
     if (!(results instanceof Promise)) results = Promise.resolve(results)
     return results.then(results => {
-      const result = results[0]
+      const name = mention.substring(1)
+      const result = results.find(r => r.name === name)
       if (!result) return {chatCompletions: []}
       return {chatCompletions: [], stagedMessage: applyResultToStagedMessage(result, fullMatch, message)}
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "other",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "The Chatternet feature platform",
   "author": "Tony Gentilcore <tony@other.xyz>",
   "repository": "other-xyz/other.js",


### PR DESCRIPTION
They still correctly autocomplete, they just don't auto mention. I _think_ this
fixes the issue @adamrothman reported in #feedback.

Ref #12, https://github.com/other-xyz/other-chat-web/issues/246
