### PR TITLE
Return chat complete results for '#' and '@'

### DIFF
--- a/builtins/__tests__/core.spec.js
+++ b/builtins/__tests__/core.spec.js
@@ -170,6 +170,74 @@ describe('core', () => {
       })
     })
 
+    it('completes all identities and identity subchannels for @', (done) => {
+      core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: '@'}, tag: 123})
+      setImmediate(() => {
+        expect(core.userAgent.emit.calls.count()).toEqual(2)
+        expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {results: [
+          {
+            id: '234',
+            name: 'Archer',
+            isIdentity: true,
+          },
+          {
+            id: '345',
+            name: 'cheryl',
+            isIdentity: true,
+          },
+          {
+            id: '456',
+            name: 'cyril',
+            isIdentity: true,
+          },
+          {
+            id: '567',
+            name: 'krieger',
+            isIdentity: true,
+          },
+          {
+            id: '678',
+            name: 'krieger',
+            isIdentity: true,
+          },
+          {
+            id: '901',
+            name: 'dangerzone',
+            parentId: '234',
+          },
+        ], layout: 'column', replyTag: 123})
+        done()
+      })
+    })
+
+    it('completes all channels and subchannels for #', (done) => {
+      core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: '#'}, tag: 123})
+      setImmediate(() => {
+        expect(core.userAgent.emit.calls.count()).toEqual(2)
+        expect(core.userAgent.emit).toHaveBeenCalledWith('SET_CHAT_COMPLETE_RESULTS', {results: [
+          {
+            id: '789',
+            name: 'isis',
+          },
+          {
+            id: '890',
+            name: 'espionage',
+            parentId: '789',
+          },
+          {
+            id: '901',
+            name: 'dangerzone',
+            parentId: '234',
+          },
+          {
+            id: '987',
+            name: 'kgb',
+          },
+        ], layout: 'column', replyTag: 123})
+        done()
+      })
+    })
+
     it('completes multiple with different names', (done) => {
       core.userAgent.emit('SET_STAGED_MESSAGE', {message: {text: '@c'}, tag: 123})
       setImmediate(() => {

--- a/builtins/core.other.js
+++ b/builtins/core.other.js
@@ -2,7 +2,7 @@ const {fetch, Feature} = require('other')
 
 const feature = new Feature({
   name: 'Core',
-  version: '0.5.0',
+  version: '0.5.1',
   dependencies: {
     otherjs: '^3.2.x',
   },
@@ -33,6 +33,7 @@ feature.listen({
       return Object.keys(entities)
           .filter((id) => {
             const entity = entities[id]
+            if (!lowerQuery && !requireOnlyIdentities && entity.isIdentity) return false
             return (!requireOnlyIdentities ||
                     entity.isIdentity ||
                     entity.parentId && (entities[entity.parentId] || {}).isIdentity) &&

--- a/lib/MentionListener.js
+++ b/lib/MentionListener.js
@@ -1,8 +1,8 @@
 import Listener from './Listener'
 
 const illegalMention = '\u0000-\u002E\u003A-\u0040\u005B-\u0060\u007B-\u007F'
-const partialMentionRegExp = new RegExp(`(?:^|[\\s\\n])([@#][^${illegalMention}]+)$`, 'im')
-const fullMentionRegExp = new RegExp(`(?:^|[\\s\\n])([@#][^${illegalMention}]+)(?=$|[${illegalMention}])`, 'im')
+const partialMentionRegExp = new RegExp(`(?:^|[\\s\\n])([@#][^${illegalMention}]*)$`, 'im')
+const fullMentionRegExp = new RegExp(`(?:^|[\\s\\n])([@#][^${illegalMention}]*)(?=$|[${illegalMention}])`, 'im')
 
 function applyResultToStagedMessage(result, match, stagedMessage) {
   const {entities, text} = stagedMessage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "other",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "description": "The Chatternet feature platform",
   "author": "Tony Gentilcore <tony@other.xyz>",
   "repository": "other-xyz/other.js",


### PR DESCRIPTION
The former returns all channels and subchannels. The latter returns all
identities and identy subchannels.

Ref https://github.com/other-xyz/other-chat-web/issues/246