### PR TITLE
Add a message action for viewing feature source.

### DIFF
--- a/builtins/__tests__/core.spec.js
+++ b/builtins/__tests__/core.spec.js
@@ -28,6 +28,31 @@ describe('core', () => {
     })
   })
 
+  it('allows viewing feature source', (done) => {
+    core.userAgent.emit('SET_ACTIVE_IDENTITY', {
+      identity: {
+        id: 123,
+      },
+      tag: 456,
+    })
+    core.userAgent.emit('SET_SELECTED_MESSAGES', {
+      messages: [{
+        id: 789,
+        identityId: 123,
+        attachments: [{
+          type: 'feature',
+          url: 'https://apps.other.chat/examples/map.other.js',
+        }],
+      }],
+      tag: 987,
+    })
+    setImmediate(() => {
+      expect(core.userAgent.emit.calls.count()).toEqual(3)
+      expect(core.userAgent.emit).toHaveBeenCalledWith('SET_MESSAGE_ACTIONS', {actions: ['view source', 'delete'], replyTag: 987})
+      done()
+    })
+  })
+
   it('disallows deleting messages you do not own', (done) => {
     core.userAgent.emit('SET_ACTIVE_IDENTITY', {
       identity: {


### PR DESCRIPTION
Currently this just trivially tells the client to navigate to the feature's
URL. This'll be more useful when we build in logic for understanding github
URLs.

Ref https://github.com/other-xyz/other-chat-web/issues/289