### PR TITLE
Always give the feature URL when installing a feature.

### DIFF
--- a/builtins/core.other.js
+++ b/builtins/core.other.js
@@ -25,9 +25,12 @@ if (feature.provideActions) {  // TODO: Remove this guard when clients support 3
             on() {
               const installArgs = firstFeature.isCloudEmbeddable ? {
                 entityId: feature.userAgent.channel.id,
+                entityType: 'channel',
                 featureIdentity: firstFeature.identity,
+                featureUrl: firstFeature.url,
               } : {
                 entityId: feature.userAgent.channel.id,
+                entityType: 'channel',
                 featureUrl: firstFeature.url,
               }
               feature.chatternet.installFeature(installArgs)
@@ -41,6 +44,7 @@ if (feature.provideActions) {  // TODO: Remove this guard when clients support 3
             on() {
               feature.chatternet.installFeature({
                 entityId: feature.userAgent.identity.id,
+                entityType: 'identity',
                 featureUrl: firstFeature.url,
               })
             },

--- a/lib/Chatternet.js
+++ b/lib/Chatternet.js
@@ -75,6 +75,8 @@ export default class Chatternet extends EventEmitter {
    * @event Chatternet#INSTALL_FEATURE
    * @mixes event:TAGGED_MESSAGE
    * @param {!string} entityId - The entity on which to install.
+   * @param {!string} entityType - The type of entity on which to install. One of
+   *     'channel' or 'identity'.
    * @param {string} featureIdentity - The identity ID of the feature to
    *     install. Iff present, the feature is executed in the cloud.
    *     Mutually exclusive with featureUrl.
@@ -96,6 +98,8 @@ export default class Chatternet extends EventEmitter {
    * @event Chatternet#UNINSTALL_FEATURE
    * @mixes event:TAGGED_MESSAGE
    * @param {!string} entityId - The entity from which to uninstall.
+   * @param {!string} entityType - The type of entity from which to uninstall. One
+   *     of 'channel' or 'identity'.
    * @param {string} featureIdentity - The identity ID of the feature to
    *     install. Mutually exclusive with featureUrl.
    * @param {string} featureUrl - The URL of the feature to install.
@@ -147,8 +151,8 @@ export default class Chatternet extends EventEmitter {
     return new Identity({id, chatternet: this}) // TODO: Implement me.
   }
 
-  installFeature({entityId, featureIdentity, featureUrl}) {
-    this.emit(INSTALL_FEATURE, {entityId, featureIdentity, featureUrl})
+  installFeature({entityId, entityType, featureIdentity, featureUrl}) {
+    this.emit(INSTALL_FEATURE, {entityId, entityType, featureIdentity, featureUrl})
   }
 
   /**
@@ -163,7 +167,7 @@ export default class Chatternet extends EventEmitter {
     })
   }
 
-  uninstallFeature({entityId, featureIdentity, featureUrl}) {
-    this.emit(UNINSTALL_FEATURE, {entityId, featureIdentity, featureUrl})
+  uninstallFeature({entityId, entityType, featureIdentity, featureUrl}) {
+    this.emit(UNINSTALL_FEATURE, {entityId, entityType, featureIdentity, featureUrl})
   }
 }

--- a/lib/embedder/ChatternetRestClient.js
+++ b/lib/embedder/ChatternetRestClient.js
@@ -148,10 +148,11 @@ export default class ChatternetRestClient {
     })
   }
 
-  putChannelFeature(channelId, featureId) {
+  putChannelFeature(channelId, featureUrl, featureIdentity) {
     return this._fetchJSON('POST', `/channel/${channelId}/feature`, {
       feature: {
-        id: featureId,
+        identityId: featureIdentity,
+        url: featureUrl,
       },
     })
   }

--- a/lib/embedder/FeatureHost.js
+++ b/lib/embedder/FeatureHost.js
@@ -36,9 +36,9 @@ export default class FeatureHost extends FeatureMetadata {
         break
       }
       case chatternet.INSTALL_FEATURE: {
-        const {entityId, featureIdentity, featureUrl} = args[0]
-        if (featureIdentity) {
-          this.client.putChannelFeature(entityId, featureIdentity)
+        const {entityId, entityType, featureIdentity, featureUrl} = args[0]
+        if (entityType === 'channel') {
+          this.client.putChannelFeature(entityId, featureUrl, featureIdentity)
         } else {
           this.client.putIdentityFeature(entityId, featureUrl)
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "other",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "description": "other.js - the chatternet platform",
   "author": "Post Social, inc. <root@other.xyz>",
   "repository": "other-xyz/other.js",


### PR DESCRIPTION
Previously the API only required the feature's identity id. Currently the API
doesn't work, but I'm proposing it work like this.

Ref https://github.com/other-xyz/courier/issues/184